### PR TITLE
Set correct classname on import and allow greater traversal

### DIFF
--- a/src/Tasks/FileMigrationTask.php
+++ b/src/Tasks/FileMigrationTask.php
@@ -140,15 +140,18 @@ class FileMigrationTask extends BuildTask
      */
     protected function processDirectory($path)
     {
-        $parts = explode('/', $path);
-        $start = count($parts) - 4;
+        $existing_path = self::config()->get("existing_file_system_path");
+        $parts = explode('/', str_replace(dirname($existing_path), "", $path));
+        $start = 0;
 
         while ($start < count($parts) - 1) {
             $reImplode[] = $parts[$start];
             $start++;
         }
 
-        $checkDirectory = $this->config()->get('base_upload_folder') . '/' . implode('/', $reImplode);
+        $checkDirectory = $this
+            ->config()
+            ->get('base_upload_folder') . '/' . implode('/', $reImplode);
 
         if (!isset($this->directory_map[$checkDirectory])) {
             if ($folder = Folder::find_or_make($this->config()->get('base_upload_folder') . '/' . implode('/', $reImplode))) {


### PR DESCRIPTION
This PR contains a few fixes:

1. If importing an `Image` (or other class name that extends `File`), this importer doesn't detect it (and defaults to just setting the classname to `File`. I have updated the script to attempt to find the correct file class.

2. Files don't seem t publish, unless I use `FIle::publishRecursive()`.

3. I have found if you are importing files with a lot of sub directories, the current import fails, I have added a fix that should theoretically traverse unlimited directories.